### PR TITLE
Add WebKit vendor prefix for user-select

### DIFF
--- a/style/virtual-cursor.css
+++ b/style/virtual-cursor.css
@@ -14,6 +14,7 @@
   pointer-events: none;
   transform: translate(-1px);
   user-select: none;
+  -webkit-user-select: none;
   border-left: 2px solid var(--prosemirror-virtual-cursor-color);
 }
 


### PR DESCRIPTION
Without it, user-select: none wasn't enabled in Safari, making Arrow Up not work for cursor movement to the beginning of the first line.

Fixes #14