### PR TITLE
feat: warn for marks with `inclusive` as true

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,30 @@ npm install prosemirror-virtual-cursor
 ## Usage
 
 ```ts
-import 'prosemirror-virtual-cursor/style/virtual-cursor.css'
+import 'prosemirror-virtual-cursor/style/virtual-cursor.css';
 
-import { createVirtualCursor } from 'prosemirror-virtual-cursor'
+import { createVirtualCursor } from 'prosemirror-virtual-cursor';
 
-const plugin = createVirtualCursor()
+const plugin = createVirtualCursor();
 ```
 
+## Options
+
+### Cursor color
+
 The default color of the cursor is red. You can change it by overriding the CSS variable `--prosemirror-virtual-cursor-color`. You can also copy all the CSS rules from `style/virtual-cursor.css` to your own stylesheet and change more things.
+
+### `skipWarning`
+
+By default, prosemirror-virtual-cursor will warn you if any mark has [`inclusive`](https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive) set to `false`, as `inclusive` is not useful for prosemirror-virtual-cursor. You can disable this warning by setting `skipWarning` to `true`. You can also specify an array of mark names to skip the warning for specific marks.
+
+```ts
+const plugin = createVirtualCursor({ skipWarning: true });
+```
+
+```ts
+const plugin = createVirtualCursor({ skipWarning: ['mark_type_name'] });
+```
 
 ## License
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -12,9 +12,8 @@
 <body>
     <div id=content style="display: none">
         <h1>prosemirror-virtual-cursor</h1>
-        <p>hello <em>italic</em></p>
+        <p>hello <em>italic</em> and <strong>bold</strong></p>
         <p>This is a <a href="https://example.com">Link</a>.</p>
-        <p>fi ii ff if</p>
     </div>
     <div class="full" spellcheck="false"></div>
     <script type="module" src="/main.ts"></script>

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -15,9 +15,17 @@ import { exampleSetup } from 'prosemirror-example-setup';
 
 import { createVirtualCursor } from '../src/index';
 
+const { marks, nodes } = schema.spec;
+
+marks.forEach((_key, value) => {
+  if (value.inclusive === false) {
+    value.inclusive = true;
+  }
+});
+
 const demoSchema = new Schema({
-  nodes: addListNodes(schema.spec.nodes as any, 'paragraph block*', 'block'),
-  marks: schema.spec.marks,
+  nodes: addListNodes(nodes, 'paragraph block*', 'block'),
+  marks,
 });
 
 const plugins = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,7 @@ function restartAnimation(element: HTMLElement, className: string) {
 }
 
 function checkInclusive(schema: Schema, skipWarning: string[]) {
-  for (let [mark, type] of Object.entries(schema.marks)) {
+  for (const [mark, type] of Object.entries(schema.marks)) {
     if (type.spec.inclusive === false && !skipWarning.includes(mark)) {
       console.warn(
         `[prosemirror-virtual-cursor] Virtual cursor does not work well with marks that have inclusive set to false. Please consider removing the inclusive option from the "${mark}" mark or adding it to the "skipWarning" option.`


### PR DESCRIPTION
Closes https://github.com/ocavue/prosemirror-virtual-cursor/issues/17


As mentioned in https://github.com/ocavue/prosemirror-virtual-cursor/issues/17, the `inclusive: true` is useless when using `prosemirror-virtual-cursor`. I don't want to implicitly change the schema spec without the user's knowledge, so I decided to warn the user. This PR also adds a `skipWarning` option to disable the warning.




https://github.com/ocavue/prosemirror-virtual-cursor/assets/24715727/f2c3fa1d-4b65-415c-a000-54d5c9c01144

