### PR TITLE
fix: put the cursor at the start of the next line on Chrome

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,8 +153,8 @@ function getCursorRect(
 
   range.collapse(toStart);
   const rects = range.getClientRects();
-  // If the cursor is at the end of the line, there would be two rects. We
-  // prefer the last one, which is at the start of the next line.
+  // On Chrome, if the cursor is at the end of the line, there would be two
+  // rects. We prefer the last one, which is at the start of the next line.
   const rect = rects?.length ? rects[rects.length - 1] : null;
   if (rect?.height) return rect;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,9 +152,11 @@ function getCursorRect(
   if (!range) return null;
 
   range.collapse(toStart);
-  const rect = range.getBoundingClientRect();
-
-  if (rect.height) return rect;
+  const rects = range.getClientRects();
+  // If the cursor is at the end of the line, there would be two rects. We
+  // prefer the last one, which is at the start of the next line.
+  const rect = rects?.length ? rects[rects.length - 1] : null;
+  if (rect?.height) return rect;
 
   return view.coordsAtPos(view.state.selection.head);
 }


### PR DESCRIPTION

https://github.com/ocavue/prosemirror-virtual-cursor/assets/24715727/a229c391-f30d-4133-8cf1-75a47e0d94c1


https://github.com/ocavue/prosemirror-virtual-cursor/assets/24715727/67d04737-3cdb-4198-a127-489f388f46f4

Closes https://github.com/ocavue/prosemirror-virtual-cursor/issues/25